### PR TITLE
Refactoring

### DIFF
--- a/Controller/REST/ScheduledCampaignRESTController.php
+++ b/Controller/REST/ScheduledCampaignRESTController.php
@@ -78,25 +78,25 @@ class ScheduledCampaignRESTController extends BaseController
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $repository = $this->getDoctrine()->getManager();
+            $em = $this->getDoctrine()->getManager();
 
             // Make sure that data stays intact by using transactions.
             try {
-                $repository->getConnection()->beginTransaction();
+                $em->getConnection()->beginTransaction();
 
-                $repository->persist($campaign);
+                $em->persist($campaign);
 
                 // We need the campaign ID for storing the hooks. Hence we must flush here.
-                $repository->flush();
+                $em->flush();
 
                 $hookService = $this->get('campaignchain.core.hook');
                 $campaign = $hookService->processHooks(ScheduledCampaignController::BUNDLE_NAME, ScheduledCampaignController::MODULE_IDENTIFIER, $campaign, $form, true);
 
-                $repository->flush();
+                $em->flush();
 
-                $repository->getConnection()->commit();
+                $em->getConnection()->commit();
             } catch (\Exception $e) {
-                $repository->getConnection()->rollback();
+                $em->getConnection()->rollback();
 
                 return $this->errorResponse($e->getMessage());
             }


### PR DESCRIPTION
- fix code style
- extract queries to CampaignChainCoreBundle:Campaign repository
- remove unused namespace imports
- extract form generation to getCampaignType() to reduce boiler plate
- use $this->addFlash() instead of $this->get('session')->getFlashBag()->add()
- use $this->redirectToRoute() instead of $this->redirect($this->generateUrl())
- rename $repository to $em, because it contains the Entity Manager and not a repository
- replace serializer generation with a serializer service to reduce boiler plate
- inject serializer service where necessary
- remove unnecessary $response variable
- remove unnecessary $response->setStatusCode(Response::HTTP_OK) - it's already the default